### PR TITLE
Add Compatibility for Ruby 3.2+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,19 @@ gem 'mdl', '~> 0.12.0'
 gem 'remedy', '0.2.0'
 gem 'pry'
 gem 'reline', '0.3.2'
+gem 'rake'
 #gem 'redcarpet'
 #gem "espeak-ruby", require: "espeak"
 # this gem is only for checking/linting code
 # gem 'rubocop'
 
+if RUBY_VERSION > '3.3.0'
+  gem 'base64'
+end
+
+if RUBY_VERSION > '3.4.0'
+  gem 'fiddle'
+end
 
 # This gem is only used to generate documentation
 gem 'yard'

--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,7 @@ if RUBY_VERSION > '3.4.0'
   gem 'fiddle'
 end
 
+gem 'minitest'
+
 # This gem is only used to generate documentation
 gem 'yard'

--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ in later Ruby versions.  Pattern matching was introduced in Ruby 2.7 as an exper
 feature. It was improved in Ruby 3.0. This version of Vier/Vish was tested in
 in Ruby version 3.1.2.
 
-Note 2 about  Ruby versions:
-
-There is an  undiagnosed problem with  using  Ruby  versions later than 3.1.
-As of the release Viper 2.0.14, please use Ruby versions  <= 3.1.2
-or >= than  2.7
-
 
 ## Note on terminal emulators for use with Viper.
 

--- a/lib/bufnode/buf_reader.rb
+++ b/lib/bufnode/buf_reader.rb
@@ -6,7 +6,7 @@ class BufReader
   end
 
   def read
-    result = ''
+    result = String.new
     node = @io
     until node.nil?
       result << node['line'].string

--- a/lib/runtime/base_command.rb
+++ b/lib/runtime/base_command.rb
@@ -23,10 +23,10 @@ class BaseCommand < BinCommand::NixCommand
 
   def args_parse!(args)
     @options = {}
-    args.select { |e| e =~ /^\-.+/ }
+    args.select { |e| e.respond_to?(:=~) && e =~ /^\-.+/ }
         .map { |e| e[1..-1].to_sym }
         .each { |e| @options[e] = true }
-    args.reject { |e| e =~ /^\-.+/ }
+    args.reject { |e| e.respond_to?(:=~) && e =~ /^\-.+/ }
   end
 
   def message(*phrases, stream:, env:, sep:)

--- a/lib/runtime/vfs_root.rb
+++ b/lib/runtime/vfs_root.rb
@@ -102,7 +102,7 @@ class VFSRoot
     !start[elements[0]].nil?
   end
 
-  def creat(path, object = StringIO.new(''))
+  def creat(path, object = StringIO.new())
     start, *elements = path_to_elements path
     my_node = node(elements[0..-2], start)
     my_node[elements[-1]] = object

--- a/lib/vish/lexer.rb
+++ b/lib/vish/lexer.rb
@@ -33,7 +33,7 @@ class Lexer
     unless [" ", "\t"].member?(at)
       return false
     end
-    result = ''
+    result = String.new
     while @cursor < @fin
       if @source[@cursor] == ' ' or @source[@cursor] == "\t"
         result << @source[@cursor]
@@ -47,7 +47,7 @@ class Lexer
 
   def comment
   return false unless (at == '#')
-  result = ''
+  result = String.new
 
   while @cursor < @fin
     if @source[@cursor] == '#'

--- a/minitest/test_api.rb
+++ b/minitest/test_api.rb
@@ -34,11 +34,11 @@ class ArrayExtenderTests < MiniTest::Test
     assert_not_empty l
   end
   def test_regexify_returns_regexp_class
-    result = regexify 'a'
+    result = regexify 'a'.dup
     assert_is result, Regexp
   end
   def test_regexify_w_pattern_matches_input
-    result = regexify 'cat'
+    result = regexify 'cat'.dup
     assert(!!'cat'.match(result))
   end
   def test_rangify

--- a/minitest/test_blankable.rb
+++ b/minitest/test_blankable.rb
@@ -5,6 +5,9 @@ require_relative 'test_helper'
 class BlankableTests < MiniTest::Test
   def mk_obj &blk
     obj = yield
+    if obj.frozen?
+      obj = obj.dup
+    end
     obj.extend Blankable
     obj
   end
@@ -14,12 +17,12 @@ class BlankableTests < MiniTest::Test
     assert obj.blank?
   end
   def test_true_if_empty
-    obj = ''
+    obj = ''.dup
     obj.extend Blankable
     assert obj.blank?
   end
   def test_true_if_only_contains_white_space
-    obj = '     '
+    obj = '     '.dup
     obj.extend Blankable
     assert obj.blank?
   end
@@ -32,7 +35,7 @@ class BlankableTests < MiniTest::Test
     assert_false obj.blank?
   end
   def test_false_when_not_empty
-    obj = mk_obj { 'hello' }
+    obj = mk_obj { 'hello'.dup }
         assert_false obj.blank?
   end
   # In Ruby 3.0 Ranges are frozen and cannot be extended

--- a/minitest/test_helper.rb
+++ b/minitest/test_helper.rb
@@ -38,6 +38,11 @@ def boot_etc
   vm
 end
 
+if !defined?(MiniTest)
+  require 'minitest'
+  MiniTest = Minitest
+end
+
 # add nothing further than the next line
 require 'minitest/autorun'
 

--- a/minitest/test_redirection.rb
+++ b/minitest/test_redirection.rb
@@ -8,7 +8,7 @@ end
 
 class RedirectionTest  < MiniTest::Test
   def setup
-    @target = ->(env:, frames:) { 'xxyyzz' }
+    @target = ->(env:, frames:) { 'xxyyzz'.dup }
     @ios = FrameStack.new
     @frames = FrameStack.new
     @frames[:ifs] = ' '


### PR DESCRIPTION
Ruby 3.2 introduced a [breaking change](https://bugs.ruby-lang.org/issues/15231) in the way that `=~` worked. Namely, it previously always returned `nil` for any object which didn't define it. After this change the method was undefined, causing errors when it was used.

This fix checks if the object has the method first before using it, emulating the old < 3.2 behavior.

In addition, later versions of Ruby stopped bundling certain standard libraries and instead split them out into gems. This causes deprecation warnings or outright errors that prevent the application from running.

These warnings and errors have been mitigated by requiring them in the Gemfile if on newer versions of Ruby.

Minitest was [removed](https://bugs.ruby-lang.org/issues/9711) from Ruby's standard library in version 2.2.

I added Minitest to the list of required gems to support this.

I have also aliased `Minittest` to `MiniTest` (with the "t" in "Test" capitalized) to support the way it is used in the code.

Another upcoming change in Ruby is that all string literals will be frozen in the future, which would break Viper and its tests.

To mitigate this, I used `String.new` instead of empty quotes where possible, checked if the value was frozen and created a copy of it using `dup` where it would be modified (including by extending the object), or if all else failed simply copied the string where it was defined.

I tested Viper on Ruby 3.4.2 and it and all of the minitests ran without errors.

To support Ruby 2.5 `lib/bin/ruby.rb` will need its `Ruby` class renamed, as `Ruby` will become a reserved word in 2.5. I did not make this change since I believe it affects the user interface, but I would suggest `Rbeval` or similar for the new class name.