### PR TITLE
Update to Remedy v0.5.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 # gem 'kpeg', '1.1.0'
 gem 'mdl', '~> 0.12.0'
 # these gems are needed for runtime, and testing
-gem 'remedy', '0.2.0'
+gem 'remedy', '~> 0.5.0'
 gem 'pry'
 gem 'reline', '0.3.2'
 #gem 'redcarpet'


### PR DESCRIPTION
Viper is currently using Remedy v0.2.0 which works just fine, but v0.5.0 does fix some minor warnings I noticed while testing Viper.